### PR TITLE
Allow specification of the intake_status

### DIFF
--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -178,8 +178,13 @@ class Datasets(object):
         request_data = {
             'aggregate': aggregate,
             'select_scopes': select_scopes,
-            'intake_status': intake_status if intake_status is not None else self.default_dss_intake_status,
         }
+
+        # Attach the intake status if specified
+        if intake_status is None:
+            intake_status = self.default_dss_intake_status
+        if intake_status is not None:
+            request_data['intake_status'] = intake_status
 
         if len(filters) > 0:
             request_data['filter_scope_values'] = filters

--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -20,6 +20,12 @@ class Datasets(object):
         (defaults to None)
     """
 
+    """ 
+    Default intake status to fetch when fetching transaction info, or None to let the dataset service decide. 
+    NB: Can be set statically with Datasets.default_dss_intake_status = '...'
+    """
+    default_dss_intake_status = None
+
     def __init__(self, bearer_token, users_base='https://users.pricecypher.com', dss_base=None, rest_options=None):
         self._bearer = bearer_token
         self._users_base = users_base
@@ -100,23 +106,35 @@ class Datasets(object):
             .scope_values(scope_id)
         )
 
-    def get_transaction_summary(self, dataset_id, bc_id='all'):
+    def get_transaction_summary(self, dataset_id, bc_id='all', intake_status=None):
         """
         Get a summary of the transactions. Contains the first and last date of any transaction in the dataset.
 
         :param int dataset_id: Dataset to retrieve summary for.
         :param str bc_id: (optional) business cell ID.
             (defaults to 'all')
+        :param str intake_status: (Optional) If specified, the summary is fetched of the last intake with this status.
         :return: Summary of the transactions.
         :rtype: TransactionSummary
         """
+        if intake_status is None:
+            intake_status = self.default_dss_intake_status
         dss_base = self._get_dss_base(dataset_id)
         return DatasetsEndpoint(self._bearer, dataset_id, dss_base, self._rest_options) \
             .business_cell(bc_id) \
             .transactions() \
-            .summary()
+            .summary(intake_status)
 
-    def get_transactions(self, dataset_id, aggregate, columns, start_date_time=None, end_date_time=None, bc_id='all'):
+    def get_transactions(
+        self,
+        dataset_id,
+        aggregate,
+        columns,
+        start_date_time=None,
+        end_date_time=None,
+        bc_id='all',
+        intake_status=None,
+    ):
         """
         Display a listing of transactions as a dataframe. The transactions can be grouped or not, using the aggregate
         parameter. The desired columns, as well as filters and aggregation methods, can be specified.
@@ -135,6 +153,7 @@ class Datasets(object):
         :param datetime end_date_time: When specified, only transactions before this date are considered.
         :param str bc_id: (optional) business cell ID.
             (defaults to 'all')
+        :param str intake_status: (Optional) If specified, transactions are fetched from the last intake of this status.
         :return: Dataframe of transactions.
         :rtype: DataFrame
         """
@@ -159,6 +178,7 @@ class Datasets(object):
         request_data = {
             'aggregate': aggregate,
             'select_scopes': select_scopes,
+            'intake_status': intake_status if intake_status is not None else self.default_dss_intake_status,
         }
 
         if len(filters) > 0:

--- a/src/pricecypher/endpoints/datasets.py
+++ b/src/pricecypher/endpoints/datasets.py
@@ -96,9 +96,13 @@ class TransactionsEndpoint(BaseEndpoint):
         # TODO: use TransactionPage schema and combine multiple pages into one transactions response.
         return self.client.post(self._url(), data=data, schema=Transaction.Schema(many=True))
 
-    def summary(self):
+    def summary(self, intake_status=None):
         """
         Get a summary of the transactions. Contains the first and last date of any transaction in the dataset.
+        :param intake_status: (Optional) intake status to fetch the summary for.
         :rtype: TransactionSummary
         """
-        return self.client.get(self._url('summary'), schema=TransactionSummary.Schema())
+        params = {}
+        if intake_status is not None:
+            params['intake_status'] = intake_status
+        return self.client.get(self._url('summary'), params=params, schema=TransactionSummary.Schema())

--- a/src/pricecypher/models/datasets.py
+++ b/src/pricecypher/models/datasets.py
@@ -15,6 +15,7 @@ class Scope:
     representation: Optional[str] = field(compare=False)
     name_dataset: str = field(compare=False)
     name_human: Optional[str] = field(compare=False)
+    name_human_times_volume: Optional[str] = field(compare=False)
     multiply_by_volume_enabled: bool = field(compare=False)
     default_aggregation_method: Optional[str] = field(compare=False)
 

--- a/src/pricecypher/models/datasets.py
+++ b/src/pricecypher/models/datasets.py
@@ -55,6 +55,7 @@ class ScopeValueTransaction:
 class ScopeConstantTransaction:
     scope_id: int
     constant: Union[str, float, None]
+    volume_multiplied_constant: Optional[Union[str, float, None]]
 
 
 @dataclass(base_schema=NamespacedSchema, frozen=True)


### PR DESCRIPTION
## Proposed changes

This PR adds support for (optionally) specifying the `intake_status` when fetching transactions or a transaction summary from the `Datasets`. If the function call to fetch these does not specify one, a class static default is used. 

The class static default allows for example to set which intake status is to be used before having some other piece of code instantiate the `Datasets` to make it use the specified intake status.

Additionally, a bug is fixed where in fetching the scopes the new `name_human_times_volume` field had nothing specified.

All changes are backward compatible with older versions of the dataset service.

Fixes [AB#273](https://dev.azure.com/jdokter/973dd796-5b61-4e4a-a52b-ab66f88cef8a/_workitems/edit/273)

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
### Unit testing
None

### Manual testing
Try out fetching different intake statuses, on the latest dataset service (which allows intake status specification) and on an older one without it, for summary and transaction fetching.

## Further comments
