### PR TITLE
Support fetching transaction scopes by ID

### DIFF
--- a/src/pricecypher/collections/scope_collection.py
+++ b/src/pricecypher/collections/scope_collection.py
@@ -6,7 +6,7 @@ class ScopeCollection(BaseCollection):
     _type = Scope
 
     def __repr__(self):
-        return "<{0} {1}>".format(self.__class__.__name__, self._list)
+        return f"<{self.__class__.__name__} {self._list}>"
 
     def __len__(self):
         """List length"""

--- a/src/pricecypher/collections/scope_value_collection.py
+++ b/src/pricecypher/collections/scope_value_collection.py
@@ -6,7 +6,7 @@ class ScopeValueCollection(BaseCollection):
     _type = ScopeValue
 
     def __repr__(self):
-        return "<{0} {1}>".format(self.__class__.__name__, self._list)
+        return f"<{self.__class__.__name__} {self._list}>"
 
     def __len__(self):
         """List length"""

--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -219,8 +219,8 @@ class Datasets(object):
         Find the scope for each provided column and return new list of columns with scope information stored inside.
 
         :param int dataset_id: Dataset ID to retrieve scopes for.
-        :param list[dict] columns: Each column should be a dict with either a `representation` or `name_dataset`
-            property.
+        :param list[dict] columns: Each column should be a dict with either a `scope_id`, `representation`
+            or `name_dataset` property.
         :param str bc_id: (optional) business cell ID.
             (defaults to 'all')
         :return: New list of columns, with for each column an added `scope` property.
@@ -229,14 +229,18 @@ class Datasets(object):
         all_scopes = self.get_scopes(dataset_id, bc_id)
 
         def add_scope(column: dict):
-            if 'representation' in column and 'name_dataset' in column:
-                raise ValueError('Both `representation` and `name_dataset` provided for column {0}'.format(str(column)))
+            if ('scope_id' in column) + ('representation' in column) + ('name_dataset' in column) != 1:
+                raise ValueError(
+                    f'Not exactly one of `scope_id`, `representation` or `name_dataset` provided for column {column}'
+                )
+            elif 'scope_id' in column:
+                scope = all_scopes.find_by_id(column['scope_id'])
             elif 'representation' in column:
                 scope = all_scopes.find_by_repr(column['representation'])
             elif 'name_dataset' in column:
                 scope = all_scopes.find_by_name_dataset(column['name_dataset'])
             else:
-                raise ValueError('No scope could be found for column {0}'.format(str(column)))
+                raise ValueError(f'No scope could be found for column {column}')
 
             return {**column, 'scope': scope}
 
@@ -325,7 +329,7 @@ class Datasets(object):
 
         for column in columns:
             scope = column['scope']
-            key = dict.get(column, 'key', 'scope_{}'.format(scope.id))
+            key = dict.get(column, 'key', f'scope_{scope.id}')
 
             scope_keys[scope.id] = key
 

--- a/src/pricecypher/endpoints/base_endpoint.py
+++ b/src/pricecypher/endpoints/base_endpoint.py
@@ -19,4 +19,4 @@ class BaseEndpoint(metaclass=ABCMeta):
             path = '/'.join(str(s).strip('/') for s in path)
         else:
             path = path.strip('/')
-        return '{}/{}'.format(self.base_url.strip('/'), path)
+        return f'{self.base_url.strip("/")}/{path}'

--- a/src/pricecypher/exceptions.py
+++ b/src/pricecypher/exceptions.py
@@ -5,7 +5,7 @@ class PriceCypherError(Exception):
         self.message = message
 
     def __str__(self):
-        return '{}: {}'.format(self.status_code, self.message)
+        return f'{self.status_code}: {self.message}'
 
 
 class RateLimitError(PriceCypherError):

--- a/src/pricecypher/rest.py
+++ b/src/pricecypher/rest.py
@@ -55,7 +55,7 @@ class RestClient(object):
         self._skip_sleep = False
 
         self.base_headers = {
-            'Authorization': 'Bearer {}'.format(self.jwt),
+            'Authorization': f'Bearer {self.jwt}',
             'Content-Type': 'application/json',
             'Accept': 'application/json',
         }


### PR DESCRIPTION
## Proposed changes

Previously, when fetching transactions, to specify which scopes to fetch they could be specified either by `representation` or by `name_dataset`. This PR adds `scope_id` as an option to this.

Fixes [AB#290](https://dev.azure.com/jdokter/973dd796-5b61-4e4a-a52b-ab66f88cef8a/_workitems/edit/290)

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
### Unit testing
None

### Manual testing
Try fetching by scope_id

## Further comments
I saw `.format` was still used. I changed it in one spot where I altered the code, so I also changed the other ones to f-strings for improved readability.