### PR TITLE
Add transaction ID filter to get_transactions

### DIFF
--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -137,6 +137,7 @@ class Datasets(object):
         end_date_time=None,
         bc_id='all',
         intake_status=None,
+        filter_transaction_ids=None,
     ):
         """
         Display a listing of transactions as a dataframe. The transactions can be grouped or not, using the aggregate
@@ -157,6 +158,7 @@ class Datasets(object):
         :param str bc_id: (optional) business cell ID.
             (defaults to 'all')
         :param str intake_status: (Optional) If specified, transactions are fetched from the last intake of this status.
+        :param list filter_transaction_ids: (Optional) If specified, only transactions with these IDs are considered.
         :return: Dataframe of transactions.
         :rtype: DataFrame
         """
@@ -188,6 +190,10 @@ class Datasets(object):
             intake_status = self.default_dss_intake_status
         if intake_status is not None:
             request_data['intake_status'] = intake_status
+
+        # Attach the to-filter transaction IDs if specified
+        if filter_transaction_ids is not None:
+            request_data['filter_transaction_ids'] = filter_transaction_ids
 
         if len(filters) > 0:
             request_data['filter_scope_values'] = filters


### PR DESCRIPTION
## Proposed changes
In the dataset service, a `filter_transaction_ids` can be specified. This PR adds support for this optional filter, which then only considers transactions in the `get_transactions` call that have one of the specified transaction IDs.

Fixes [AB#297](https://dev.azure.com/jdokter/973dd796-5b61-4e4a-a52b-ab66f88cef8a/_workitems/edit/297)

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
### Unit testing
None currently

### Manual testing
Try out the new filter, as well as making sure that without the filter it still works.

## Further comments
