### PR TITLE
Add pagination support to transactions index endpoint

### DIFF
--- a/src/pricecypher/models/__init__.py
+++ b/src/pricecypher/models/__init__.py
@@ -1,3 +1,3 @@
 from .users import Dataset
 from .datasets import Scope, ScopeValue, TransactionSummary, ScopeValueTransaction, ScopeConstantTransaction,\
-    Transaction
+    Transaction, PageMeta, TransactionsPage

--- a/src/pricecypher/models/datasets.py
+++ b/src/pricecypher/models/datasets.py
@@ -1,6 +1,7 @@
 from dataclasses import field
 from datetime import datetime
 from typing import Optional, List, Union
+from marshmallow import EXCLUDE
 from marshmallow_dataclass import dataclass
 
 from pricecypher.models.namespaced_schema import NamespacedSchema
@@ -58,7 +59,7 @@ class ScopeConstantTransaction:
     volume_multiplied_constant: Optional[Union[str, float, None]]
 
 
-@dataclass(base_schema=NamespacedSchema, frozen=True)
+@dataclass(frozen=True)
 class Transaction:
     id: Optional[int]
     external_id: Optional[str]
@@ -70,10 +71,6 @@ class Transaction:
     unit: Optional[str]
     scope_values: List[ScopeValueTransaction]
     scope_constants: List[ScopeConstantTransaction]
-
-    class Meta:
-        name = "transaction"
-        plural_name = "transactions"
 
     def to_dict(self, scope_keys):
         dic = {
@@ -99,3 +96,23 @@ class Transaction:
 
         return dic
 
+
+@dataclass(frozen=True)
+class PageMeta:
+    current_page: int
+    last_page: int
+    path: str
+
+    class Meta:
+        # Exclude other fields since we don't need them.
+        unknown = EXCLUDE
+
+
+@dataclass(frozen=True)
+class TransactionsPage:
+    meta: PageMeta
+    transactions: List[Transaction]
+
+    class Meta:
+        # Exclude other fields since we don't need them.
+        unknown = EXCLUDE


### PR DESCRIPTION
## Proposed changes

The transactions index endpoint now requests multiple pages (all available) when multiple pages are present.

Fixes [AB#296](https://dev.azure.com/jdokter/973dd796-5b61-4e4a-a52b-ab66f88cef8a/_workitems/edit/296).

## Types of changes

What types of changes does your code introduce to this repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
Explain here how to run your unit tests, and explain how to execute manual testing. 

### Unit testing
Nope :(

### Manual testing
Try `get_transactions` function for dataset with > 10,000 transactions and verify that returned data frame contains all transactions that are available.

## Further comments
n/a