### PR TITLE
Add ability to handle pages of transactions asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,14 @@ Similarly, each file in the `models` module defines the models that are provided
 The SDK that this package provides is contained in the top-level package contents.
 
 ## Deployment
-1. Execute `python3 -m build` to build the source archive and a built distribution.
-2. Execute `python3 -m twine upload dist/*` to upload the package to PyPi.
+1. Execute `python -m build` to build the source archive and a built distribution.
+2. Execute `python -m twine upload dist/*` to upload the package to PyPi.
+
+### Snapshot
+To deploy a snapshot release, follow the next steps instead.
+1. Add `-pre` to the version in `setup.cfg`.
+2. Execute `python -m build -C--global-option=egg_info -C--global-option=--tag-build=dev`.
+3. Execute `python -m twine upload dist/*`.
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -8,21 +8,48 @@ Simply execute `pip install pricecypher-sdk`
 
 ### Dataset SDK
 ```python
+import asyncio
 from pricecypher import Datasets
 
-datasets = Datasets(BEARER_TOKEN)
 
-datasets.index()
-datasets.get_meta(DATASET_ID)
-datasets.get_scopes(DATASET_ID)
-datasets.get_scope_values(DATASET_ID, SCOPE_ID)
-datasets.get_transaction_summary(DATASET_ID)
+async def handle_page(page, page_nr, last_page):
+    """ This function will be called for each individual page of transactions that is received."""
+    print(f'Handling page {page_nr}/{last_page}')
+    print(f'Nr of transactions in page: {len(page)}')
+    print(f'Handling page {page_nr}/{last_page} done')
 
-columns = [
-    {'name_dataset': 'cust_group', 'filter': ['Big', 'Small'], 'key': 'group'},
-    {'representation': 'cost_price', 'aggregate': 'sum', 'key': 'cost_price'}
-]
-datasets.get_transactions(DATASET_ID, AGGREGATE, columns)
+
+async def main():
+    async with Datasets(BEARER_TOKEN) as ds:
+        # Specify desired columns to be requested for transactions 
+        columns = [
+            {'name_dataset': 'cust_group', 'filter': ['Big', 'Small'], 'key': 'group'},
+            {'representation': 'cost_price', 'aggregate': 'sum', 'key': 'cost_price'}
+        ]
+
+        index = asyncio.create_task(ds.index())
+        meta = asyncio.create_task(ds.get_meta(DATASET_ID))
+        scopes = asyncio.create_task(ds.get_scopes(DATASET_ID))
+        values = asyncio.create_task(ds.get_scope_values(DATASET_ID, SCOPE_ID))
+        summary = asyncio.create_task(ds.get_transaction_summary(DATASET_ID))
+        transactions = asyncio.create_task(ds.get_transactions(DATASET_ID, AGGREGATE, columns))
+
+        print('datasets', await index)
+        print('transactions', await transactions)
+        print('meta', await meta)
+        print('summary', await summary)
+        print('scopes', await scopes)
+        print('scope values', await values)
+
+asyncio.run(main())
+```
+
+### Printing debug logs
+By default, debug log messages are not printed. Debug logs can be enabled using the following.
+```python
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
 ```
 
 ### Contracts

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pricecypher-sdk
-version = 0.5.0
+version = 0.6.0
 author = Deloitte Consulting B.V.
 description = Python wrapper around the different PriceCypher APIs
 long_description = file: README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     pandas>=1.4.1
     numpy>=1.18.5
     typeguard>=2.13.3
+    aiohttp>=3.8.3
 
 [options.packages.find]
 where = src

--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -228,17 +228,17 @@ class Datasets(object):
         elif end_date_time is not None:
             raise ValueError('end_date_time should be an instance of datetime.')
 
-        async def page_cb(page, page_nr, last_page):
+        async def local_page_cb(page, page_nr, last_page):
             """ This callback function will be executed for each received page of transactions. """
             if page_cb is not None:
                 logging.debug(f'Scheduling transaction page handler for page {page_nr}/{last_page}.')
-                asyncio.create_task(page_cb(self._transactions_to_df(page, scope_keys), page_nr, last_page))
+                await page_cb(self._transactions_to_df(page, scope_keys), page_nr, last_page)
 
         # Fetch transactions from the dataset service.
         transactions = await DatasetsEndpoint(self._client, dataset_id, dss_base) \
             .business_cell(bc_id) \
             .transactions() \
-            .index(request_data, page_cb)
+            .index(request_data, local_page_cb)
 
         logging.debug(f"Received all transactions at {time.strftime('%X')}, creating data frame...")
         # Map transactions to dicts based on the provided column keys and convert to pandas dataframe.

--- a/src/pricecypher/endpoints/datasets.py
+++ b/src/pricecypher/endpoints/datasets.py
@@ -1,24 +1,23 @@
+import logging
+import asyncio
+
 from pricecypher.endpoints.base_endpoint import BaseEndpoint
 from pricecypher.models import Scope, ScopeValue, TransactionSummary, TransactionsPage
-from pricecypher.rest import RestClient
 
 
 class DatasetsEndpoint(BaseEndpoint):
     """PriceCypher dataset endpoints in dataset service.
 
-    :param str bearer_token: Bearer token for PriceCypher (logical) API. Needs 'read:datasets' scope.
+    :param RestClient client: HTTP client for making API requests.
     :param int dataset_id: Dataset ID.
     :param str dss_base: (optional) Base URL for PriceCypher dataset service API.
         (defaults to https://datasets.pricecypher.com)
-    :param RestClientOptions rest_options: (optional) Set any additional options for the REST client, e.g. rate-limit.
-        (defaults to None)
     """
 
-    def __init__(self, bearer_token, dataset_id, dss_base='https://datasets.pricecypher.com', rest_options=None):
-        self.bearer_token = bearer_token
+    def __init__(self, client, dataset_id, dss_base='https://datasets.pricecypher.com'):
         self.dataset_id = dataset_id
         self.base_url = dss_base
-        self.client = RestClient(jwt=bearer_token, options=rest_options)
+        self.client = client
 
     def business_cell(self, bc_id='all'):
         """
@@ -63,20 +62,20 @@ class ScopesEndpoint(BaseEndpoint):
         self.client = client
         self.base_url = base
 
-    def index(self):
+    async def index(self):
         """
         Show a list of all scopes of the dataset.
         :rtype: list[Scope]
         """
-        return self.client.get(self._url(), schema=Scope.Schema(many=True))
+        return await self.client.get(self._url(), schema=Scope.Schema(many=True))
 
-    def scope_values(self, scope_id):
+    async def scope_values(self, scope_id):
         """
         Get all scope values for the given scope of the dataset.
         :param scope_id: Scope to get scope values for.
         :rtype: list[ScopeValue]
         """
-        return self.client.get(self._url([scope_id, 'scope_values']), schema=ScopeValue.Schema(many=True))
+        return await self.client.get(self._url([scope_id, 'scope_values']), schema=ScopeValue.Schema(many=True))
 
 
 class TransactionsEndpoint(BaseEndpoint):
@@ -87,37 +86,44 @@ class TransactionsEndpoint(BaseEndpoint):
         self.client = client
         self.base_url = base
 
-    def index(self, data, page_cb=lambda page: None):
+    async def index(self, data, page_cb):
         """
         Display a listing of transactions. The given data will be passed directly to the dataset service.
         :param page_cb: Callback function with input a single page of transactions, called for each individual page.
         :param data: See documentation of dataset service on what data can be passed.
+        :return: A list of all returned transactions, potentially across multiple pages.
         :rtype: list[Transaction]
         """
         # Perform initial request to retrieve first page of transactions and page metadata.
-        init_response = self.client.post(self._url(), data=data, schema=TransactionsPage.Schema())
+        logging.debug('Requesting first page of transactions...')
+        init_response = await self.client.post(self._url(), data=data, schema=TransactionsPage.Schema())
+        logging.debug('Received first page of transactions.')
+
         # Collect first page of transactions, which will be appended later when multiple pages are available.
         transactions = init_response.transactions
         curr_page = init_response.meta.current_page
         last_page = init_response.meta.last_page
         request_path = init_response.meta.path
 
-        page_cb(transactions)
+        # Schedule async page callback to be handled by the caller.
+        asyncio.create_task(page_cb(transactions, curr_page, last_page))
 
         # Loop over all available pages.
         for page_nr in range(curr_page + 1, last_page + 1):
+            logging.debug(f'Requesting transaction page {page_nr}/{last_page}...')
             page_path = f'{request_path}?page={page_nr}'
-            page_response = self.client.post(page_path, data=data, schema=TransactionsPage.Schema())
+            page_response = await self.client.post(page_path, data=data, schema=TransactionsPage.Schema())
+            logging.debug(f'Received transaction page {page_nr}/{last_page}.')
 
-            # Call callback function with this page of transactions
-            page_cb(page_response.transactions)
+            # Schedule async page callback function with this page of transactions.
+            asyncio.create_task(page_cb(page_response.transactions, page_nr, last_page))
 
             # Append transactions of the current page.
             transactions += page_response.transactions
 
         return transactions
 
-    def summary(self, intake_status=None):
+    async def summary(self, intake_status=None):
         """
         Get a summary of the transactions. Contains the first and last date of any transaction in the dataset.
         :param intake_status: (Optional) intake status to fetch the summary for.
@@ -126,4 +132,4 @@ class TransactionsEndpoint(BaseEndpoint):
         params = {}
         if intake_status is not None:
             params['intake_status'] = intake_status
-        return self.client.get(self._url('summary'), params=params, schema=TransactionSummary.Schema())
+        return await self.client.get(self._url('summary'), params=params, schema=TransactionSummary.Schema())

--- a/src/pricecypher/endpoints/datasets.py
+++ b/src/pricecypher/endpoints/datasets.py
@@ -87,9 +87,10 @@ class TransactionsEndpoint(BaseEndpoint):
         self.client = client
         self.base_url = base
 
-    def index(self, data):
+    def index(self, data, page_cb=lambda page: None):
         """
         Display a listing of transactions. The given data will be passed directly to the dataset service.
+        :param page_cb: Callback function with input a single page of transactions, called for each individual page.
         :param data: See documentation of dataset service on what data can be passed.
         :rtype: list[Transaction]
         """
@@ -101,10 +102,16 @@ class TransactionsEndpoint(BaseEndpoint):
         last_page = init_response.meta.last_page
         request_path = init_response.meta.path
 
+        page_cb(transactions)
+
         # Loop over all available pages.
         for page_nr in range(curr_page + 1, last_page + 1):
             page_path = f'{request_path}?page={page_nr}'
             page_response = self.client.post(page_path, data=data, schema=TransactionsPage.Schema())
+
+            # Call callback function with this page of transactions
+            page_cb(page_response.transactions)
+
             # Append transactions of the current page.
             transactions += page_response.transactions
 

--- a/src/pricecypher/endpoints/users.py
+++ b/src/pricecypher/endpoints/users.py
@@ -6,17 +6,14 @@ from pricecypher.rest import RestClient
 class UsersEndpoint(BaseEndpoint):
     """PriceCypher endpoints in user tool.
 
-    :param str bearer_token: Bearer token for PriceCypher (logical) API. Needs 'read:datasets' scope.
+    :param RestClient client: HTTP client for making API requests.
     :param str users_base: (optional) Base URL for PriceCypher user tool API.
         (defaults to https://users.pricecypher.com)
-    :param RestClientOptions rest_options: (optional) Set any additional options for the REST client, e.g. rate-limit.
-        (defaults to None)
     """
 
-    def __init__(self, bearer_token, users_base='https://users.pricecypher.com', rest_options=None):
+    def __init__(self, client, users_base='https://users.pricecypher.com'):
         self.base_url = users_base
-        self.bearer_token = bearer_token
-        self.client = RestClient(jwt=bearer_token, options=rest_options)
+        self.client = client
 
     def datasets(self):
         """
@@ -34,10 +31,10 @@ class DatasetsEndpoint(BaseEndpoint):
         self.client = client
         self.base_url = base
 
-    def index(self) -> list[Dataset]:
+    async def index(self) -> list[Dataset]:
         """List all available datasets the user has access to.
 
         :return: list of datasets.
         :rtype list[Dataset]
         """
-        return self.client.get(self._url(), schema=Dataset.Schema(many=True))
+        return await self.client.get(self._url(), schema=Dataset.Schema(many=True))


### PR DESCRIPTION
## Proposed changes
Recall that, when querying transactions, the dataset service uses a paginated response. I.e. only 10,000 transactions can be queried at a time (which we call 1 page). Currently, the SDK abstracts away from this by requesting all pages one-by-one until all transactions have been received. 

However, in some cases it can be useful to already start processing a page of transactions, while waiting for the next one to be returned. This PR adds that functionality by adding a callback parameter to the `get_transactions` function that is called after each page of transactions is received.

## Types of changes

What types of changes does your code introduce to this repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
Explain here how to run your unit tests, and explain how to execute manual testing. 

### Unit testing
n/a

### Manual testing
Install snapshot version using
```bash
pip install pricecypher-sdk==0.6.0rc0.dev0
```

Then, for instance, something like the following. It should print the different pages and their sizes (always 10,000) multiple times.

```Python
import logging
import asyncio
from pricecypher import Datasets

logging.basicConfig(level=logging.DEBUG)


async def handle_page(page, page_nr, last_page):
    print(f'Handling page {page_nr}/{last_page}')
    print(f'Nr of transactions in page: {len(page)}')
    print(f'Handling page {page_nr}/{last_page} done')


async def main():
    async with Datasets(BEARER_TOKEN) as ds:
        # Specify desired comments for transactions dataframe
        columns = [
            {'representation': 'net_sales', 'key': 'net_sales'},
            {'representation': 'cost_price', 'key': 'cost_price'}
        ]

        index = asyncio.create_task(ds.index())
        transactions = asyncio.create_task(ds.get_transactions(58, False, columns, page_cb=handle_page))
        meta = asyncio.create_task(ds.get_meta(58))
        summary = asyncio.create_task(ds.get_transaction_summary(58))

        # Wait for scopes to be requested, such that we can use one for requesting its scope values.
        scopes = await asyncio.create_task(ds.get_scopes(58))

        print('scopes', scopes)

        values = asyncio.create_task(ds.get_scope_values(58, scopes.where_type('enum')[0].id))

        print('datasets', await index)
        print('trans', await transactions)
        print('meta', await meta)
        print('summary', await summary)
        print('scope values', await values)

asyncio.run(main())
```

## Further comments
Uses Python's built-in [asyncio](https://docs.python.org/3/library/asyncio.html) to handle concurrency. This allows us to process a page of transactions while waiting for the next page of transactions to be returned by the API.
