### PR TITLE
Add ability to specify custom DNS resolution in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ output that can be visualized and/or used by other services.
 
 See the documentation on the abstract functions for further specifics.
 
+### Environment variables
+
+| Variable          | Description                                                                |
+|-------------------|----------------------------------------------------------------------------|
+| CUSTOM_DNS_DOMAIN | Use for custom domain resolution of (wildcard) domain to `$CUSTOM_DNS_IP`. |
+| CUSTOM_DNS_IP     | IP address the `CUSTOM_DNS_DOMAIN` should resolve to.                      |
+| SSL_VERIFY        | Boolean value to specify whether SSL certificates should be verified.      |
+
+
 ## Development
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pricecypher-sdk
-version = 0.5.0
+version = 0.5.1
 author = Deloitte Consulting B.V.
 description = Python wrapper around the different PriceCypher APIs
 long_description = file: README.md

--- a/src/pricecypher/rest.py
+++ b/src/pricecypher/rest.py
@@ -100,7 +100,7 @@ class RestClientOptions(object):
             self.retries = retries
 
         if 'SSL_VERIFY' in os.environ:
-            self.verify = bool(os.environ.get('SSL_VERIFY'))
+            self.verify = os.environ.get('SSL_VERIFY').lower() == 'true'
 
 
 class RestClient(object):


### PR DESCRIPTION
## Proposed changes
This PR introduces 3 new environment variables to alter DNS resolution and disable SSL verification when needed.

This allows us to resolve domain names that cannot be resolved by the host. This can happen for internal domain names within a network that is not configured correctly. 

Additionally, the verification of SSL certificates for requests sent by this package can be disabled. This can be used within PRIVATE networks when the host does not have the proper certificate authority chain present to be able to verify the SSL certificate of the requested resource.

## Types of changes

What types of changes does your code introduce to this repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

### Unit testing
n/a

### Manual testing
Let's test in client environment and merge only if it indeed resolves the DNS issue.

Install snapshot version using
```bash
pip install pricecypher-sdk==0.5.1rc0.dev0
```

Set environment variables as follows.
```bash
CUSTOM_DNS_DOMAIN=
CUSTOM_DNS_IP=
SSL_VERIFY=false
```

## Further comments
n/a
