### PR TITLE
Add config SDK to retrieve config sections as dicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ output that can be visualized and/or used by other services.
 
 See the documentation on the abstract functions for further specifics.
 
+### Environment variables
+
+| Variable          | Description                                                                |
+|-------------------|----------------------------------------------------------------------------|
+| CUSTOM_DNS_DOMAIN | Use for custom domain resolution of (wildcard) domain to `$CUSTOM_DNS_IP`. |
+| CUSTOM_DNS_IP     | IP address the `CUSTOM_DNS_DOMAIN` should resolve to.                      |
+| SSL_VERIFY        | Boolean value to specify whether SSL certificates should be verified.      |
+
+
 ## Development
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ columns = [
 datasets.get_transactions(DATASET_ID, AGGREGATE, columns)
 ```
 
+### Config SDK
+```python
+from pricecypher import ConfigSections
+
+config = ConfigSections(BEARER_TOKEN, DATASET_ID)
+
+# Print available config sections
+print(config.index())
+# Print config key-value pairs for `monitoring` section.
+print(config.get_parsed_section('monitoring'))
+# Non-existent config section returns empty dict.
+print(config.get_parsed_section('nonexistent'))
+```
+
 ### Contracts
 The `Script`, `ScopeScript`, and `QualityTestScript` abstract classes can be extended with their abstract methods
 implemented to create scripts usable in other services. 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pricecypher-sdk
-version = 0.5.0
+version = 0.5.1
 author = Deloitte Consulting B.V.
 description = Python wrapper around the different PriceCypher APIs
 long_description = file: README.md

--- a/src/pricecypher/__init__.py
+++ b/src/pricecypher/__init__.py
@@ -1,1 +1,2 @@
+from .config_sections import ConfigSections
 from .datasets import Datasets

--- a/src/pricecypher/config_sections.py
+++ b/src/pricecypher/config_sections.py
@@ -1,0 +1,52 @@
+from pricecypher.endpoints import ConfigEndpoint
+from pricecypher.models import ConfigSection
+from pricecypher.rest import RestClient
+
+
+class ConfigSections(object):
+    """
+    Config API. Exposes all available operations on dataset configs, like fetching the available sections, and
+    retrieving the key-value pairs of a section and parsing it to a dictionary.
+
+    :param str bearer_token: Bearer token for PriceCypher (logical) API. Needs 'read:configuration' scope.
+    :param str config_base: (optional) Base URL for PriceCypher config service API.
+        (defaults to the static default_config_base, which by default is https://config.pricecypher.com)
+    :param RestClientOptions rest_options: (optional) Set any additional options for the REST client, e.g. rate-limit.
+        (defaults to None)
+    """
+
+    """ Default user-tool base URL """
+    default_config_base = 'https://config.pricecypher.com'
+
+    def __init__(self, bearer_token, dataset_id, config_base=None, rest_options=None):
+        self._bearer = bearer_token
+        self._dataset_id = dataset_id
+        self._config_base = config_base if config_base is not None else self.default_config_base
+        self._rest_options = rest_options
+        self._client = RestClient(jwt=bearer_token, options=rest_options)
+
+    def index(self) -> list[ConfigSection]:
+        """
+        List all available config sections for the dataset.
+
+        :return: list of config sections.
+        :rtype list[ConfigSection]
+        """
+        return ConfigEndpoint(self._client, self._dataset_id, self._config_base).sections().index()
+
+    def get_parsed_section(self, section_key) -> dict:
+        """
+        Retrieves the config section by the given key, and parses the contained key-value pairs into a single dict.
+
+        :return: Dictionary of all key-value pairs in the given section, or an empty dict if no such section exists.
+        :rtype: dict Mapping config keys (str) to config values (any).
+        """
+        section = ConfigEndpoint(self._client, self._dataset_id, self._config_base).sections().get(section_key)
+
+        if section is None:
+            return {}
+
+        return {
+            key_value.key: key_value.value
+            for key_value in section.keys
+        }

--- a/src/pricecypher/config_sections.py
+++ b/src/pricecypher/config_sections.py
@@ -9,6 +9,7 @@ class ConfigSections(object):
     retrieving the key-value pairs of a section and parsing it to a dictionary.
 
     :param str bearer_token: Bearer token for PriceCypher (logical) API. Needs 'read:configuration' scope.
+    :param int dataset_id: Dataset that is queried by these config operations.
     :param str config_base: (optional) Base URL for PriceCypher config service API.
         (defaults to the static default_config_base, which by default is https://config.pricecypher.com)
     :param RestClientOptions rest_options: (optional) Set any additional options for the REST client, e.g. rate-limit.

--- a/src/pricecypher/endpoints/__init__.py
+++ b/src/pricecypher/endpoints/__init__.py
@@ -1,2 +1,3 @@
 from .datasets import DatasetsEndpoint
 from .users import UsersEndpoint
+from .config import ConfigEndpoint

--- a/src/pricecypher/endpoints/config.py
+++ b/src/pricecypher/endpoints/config.py
@@ -1,0 +1,43 @@
+from pricecypher.endpoints.base_endpoint import BaseEndpoint
+from pricecypher.models import ConfigSection, ConfigSectionWithKeys
+
+
+class ConfigEndpoint(BaseEndpoint):
+    """PriceCypher config service endpoints.
+
+        :param RestClient client: HTTP client for making API requests.
+        :param str users_base: (optional) Base URL for PriceCypher config service API.
+            (defaults to https://config.pricecypher.com)
+        """
+
+    def __init__(self, client, dataset_id, users_base='https://config.pricecypher.com'):
+        self.base_url = users_base
+        self.client = client
+        self.dataset_id = dataset_id
+
+    def sections(self):
+        """
+        Dataset endpoints in user tool API.
+        :rtype: DatasetsEndpoint
+        """
+        return SectionsEndpoint(self.client, self._url(['api/datasets', self.dataset_id, '/config/sections']))
+
+
+class SectionsEndpoint(BaseEndpoint):
+    """
+    PriceCypher dataset endpoints in user tool API.
+    """
+    def __init__(self, client, base):
+        self.client = client
+        self.base_url = base
+
+    def index(self) -> list[ConfigSection]:
+        """List all available sections the user has access to.
+
+        :return: list of datasets.
+        :rtype list[Dataset]
+        """
+        return self.client.get(self._url(), schema=ConfigSection.Schema(many=True))
+
+    def get(self, section_key) -> ConfigSectionWithKeys:
+        return self.client.get(self._url(section_key), schema=ConfigSectionWithKeys.Schema(many=False))

--- a/src/pricecypher/endpoints/config.py
+++ b/src/pricecypher/endpoints/config.py
@@ -1,43 +1,59 @@
+from typing import Optional
+
 from pricecypher.endpoints.base_endpoint import BaseEndpoint
+from pricecypher.exceptions import PriceCypherError
 from pricecypher.models import ConfigSection, ConfigSectionWithKeys
 
 
 class ConfigEndpoint(BaseEndpoint):
     """PriceCypher config service endpoints.
 
-        :param RestClient client: HTTP client for making API requests.
-        :param str users_base: (optional) Base URL for PriceCypher config service API.
-            (defaults to https://config.pricecypher.com)
-        """
+    :param RestClient client: HTTP client for making API requests.
+    :param int dataset_id: Dataset ID.
+    :param str config_base: (optional) Base URL for PriceCypher config service API.
+        (defaults to https://config.pricecypher.com)
+    """
 
-    def __init__(self, client, dataset_id, users_base='https://config.pricecypher.com'):
-        self.base_url = users_base
+    def __init__(self, client, dataset_id, config_base='https://config.pricecypher.com'):
+        self.base_url = config_base
         self.client = client
         self.dataset_id = dataset_id
 
     def sections(self):
         """
-        Dataset endpoints in user tool API.
-        :rtype: DatasetsEndpoint
+        Sections endpoints in config service API.
+        :rtype: SectionsEndpoint
         """
         return SectionsEndpoint(self.client, self._url(['api/datasets', self.dataset_id, '/config/sections']))
 
 
 class SectionsEndpoint(BaseEndpoint):
     """
-    PriceCypher dataset endpoints in user tool API.
+    PriceCypher sections endpoints in config service API.
     """
     def __init__(self, client, base):
         self.client = client
         self.base_url = base
 
     def index(self) -> list[ConfigSection]:
-        """List all available sections the user has access to.
+        """List all available config sections for the dataset.
 
-        :return: list of datasets.
-        :rtype list[Dataset]
+        :return: list of config sections.
+        :rtype list[ConfigSection]
         """
         return self.client.get(self._url(), schema=ConfigSection.Schema(many=True))
 
-    def get(self, section_key) -> ConfigSectionWithKeys:
-        return self.client.get(self._url(section_key), schema=ConfigSectionWithKeys.Schema(many=False))
+    def get(self, section_key) -> Optional[ConfigSectionWithKeys]:
+        """ Retrieve the config section, with its contained key-value pairs, using the given section key.
+
+        :param str section_key: Key of the section to retrieve.
+        :return: The requested config section with its contained key-value pairs, or `None` if no such section exists.
+        :rtype Optional[ConfigSectionWithKeys]
+        """
+        try:
+            return self.client.get(self._url(section_key), schema=ConfigSectionWithKeys.Schema(many=False))
+        except PriceCypherError as e:
+            if e.status_code == 404:
+                return None
+            else:
+                raise e

--- a/src/pricecypher/models/__init__.py
+++ b/src/pricecypher/models/__init__.py
@@ -1,3 +1,4 @@
 from .users import Dataset
 from .datasets import Scope, ScopeValue, TransactionSummary, ScopeValueTransaction, ScopeConstantTransaction,\
     Transaction, PageMeta, TransactionsPage
+from .config import ConfigSection, ConfigSectionWithKeys

--- a/src/pricecypher/models/config.py
+++ b/src/pricecypher/models/config.py
@@ -1,0 +1,48 @@
+from dataclasses import field
+from typing import List, Optional, Any, Union
+
+from marshmallow import EXCLUDE
+from marshmallow_dataclass import dataclass
+
+from pricecypher.models.namespaced_schema import NamespacedSchema
+
+
+@dataclass(base_schema=NamespacedSchema, frozen=True)
+class ConfigSection:
+    key: str = field(compare=True)
+    name: str = field(compare=False)
+    order: int = field(compare=False)
+
+    class Meta:
+        name = "section"
+        plural_name = "sections"
+
+
+@dataclass(frozen=True)
+class ConfigKey:
+    key: str = field(compare=True)
+    label: str = field(compare=False)
+    data_type: str = field(compare=False)
+    schema: Union[None, str] = field(compare=False)
+    order: int = field(compare=False)
+    is_array: bool = field(compare=False)
+    business_cell_id: Union[str, int] = field(compare=False)
+    value: Any = field(compare=False)
+    possible_values: Optional[Any] = field(compare=False)
+
+    class Meta:
+        unknown = EXCLUDE
+
+
+@dataclass(base_schema=NamespacedSchema, frozen=True)
+class ConfigSectionWithKeys:
+    id: int = field(compare=True)
+    key: str = field(compare=False)
+    name: str = field(compare=False)
+    order: int = field(compare=False)
+    keys: List[ConfigKey]
+
+    class Meta:
+        name = "section"
+        plural_name = "sections"
+        unknown = EXCLUDE

--- a/src/pricecypher/models/config.py
+++ b/src/pricecypher/models/config.py
@@ -16,6 +16,7 @@ class ConfigSection:
     class Meta:
         name = "section"
         plural_name = "sections"
+        unknown = EXCLUDE
 
 
 @dataclass(frozen=True)

--- a/src/pricecypher/models/datasets.py
+++ b/src/pricecypher/models/datasets.py
@@ -1,6 +1,7 @@
 from dataclasses import field
 from datetime import datetime
 from typing import Optional, List, Union
+
 from marshmallow import EXCLUDE
 from marshmallow_dataclass import dataclass
 
@@ -23,6 +24,7 @@ class Scope:
     class Meta:
         name = "scope"
         plural_name = "scopes"
+        unknown = EXCLUDE
 
 
 @dataclass(base_schema=NamespacedSchema, frozen=True)
@@ -34,6 +36,7 @@ class ScopeValue:
     class Meta:
         name = "scope_value"
         plural_name = "scope_values"
+        unknown = EXCLUDE
 
 
 @dataclass(base_schema=NamespacedSchema, frozen=True)
@@ -44,6 +47,7 @@ class TransactionSummary:
     class Meta:
         name = "summary"
         plural_name = "summaries"
+        unknown = EXCLUDE
 
 
 @dataclass(frozen=True)
@@ -51,12 +55,18 @@ class ScopeValueTransaction:
     scope_id: int
     value: Optional[str]
 
+    class Meta:
+        unknown = EXCLUDE
+
 
 @dataclass(frozen=True)
 class ScopeConstantTransaction:
     scope_id: int
     constant: Union[str, float, None]
     volume_multiplied_constant: Optional[Union[str, float, None]]
+
+    class Meta:
+        unknown = EXCLUDE
 
 
 @dataclass(frozen=True)
@@ -71,6 +81,9 @@ class Transaction:
     unit: Optional[str]
     scope_values: List[ScopeValueTransaction]
     scope_constants: List[ScopeConstantTransaction]
+
+    class Meta:
+        unknown = EXCLUDE
 
     def to_dict(self, scope_keys):
         dic = {

--- a/src/pricecypher/models/users.py
+++ b/src/pricecypher/models/users.py
@@ -1,6 +1,8 @@
 from dataclasses import field
 from datetime import datetime
 from typing import Optional
+
+from marshmallow import EXCLUDE
 from marshmallow_dataclass import dataclass
 
 from pricecypher.models.namespaced_schema import NamespacedSchema
@@ -18,3 +20,4 @@ class Dataset:
     class Meta:
         name = "dataset"
         plural_name = "datasets"
+        unknown = EXCLUDE

--- a/src/pricecypher/rest.py
+++ b/src/pricecypher/rest.py
@@ -5,7 +5,7 @@ import requests
 from time import sleep
 from random import randint
 from datetime import datetime
-from marshmallow import Schema
+from marshmallow import Schema, EXCLUDE
 
 from .exceptions import PriceCypherError, RateLimitError
 
@@ -301,7 +301,7 @@ class JsonEncoder(json.JSONEncoder):
 class JsonResponse(Response):
     def __init__(self, response, schema: Schema = None):
         if schema is not None and response.status_code < 400:
-            content = schema.loads(json_data=response.text)
+            content = schema.loads(json_data=response.text, unknown=EXCLUDE)
         else:
             content = json.loads(response.text)
         super(JsonResponse, self).__init__(response.status_code, content, response.headers)

--- a/src/pricecypher/rest.py
+++ b/src/pricecypher/rest.py
@@ -100,7 +100,7 @@ class RestClientOptions(object):
             self.retries = retries
 
         if 'SSL_VERIFY' in os.environ:
-            self.verify = bool(os.environ.get('SSL_VERIFY'))
+            self.verify = os.environ.get('SSL_VERIFY').lower() == 'true'
 
 
 class RestClient(object):


### PR DESCRIPTION
~PR #23 should be merged first.~

## Proposed changes
Adds following functions to query PriceCypher config service.
* `config.index()` to retrieve the available config sections for a dataset
* `config.get_parsed_section()` to retrieve the key-value pairs of a config section as dict.

## Types of changes

What types of changes does your code introduce to this repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

### Unit testing
n/a

### Manual testing
Install snapshot version using the following command.

```bash
pip install pricecypher-sdk==0.5.2rc0.dev0
```

See the updated readme on how to use the newly added functions.

## Further comments
n/a
