### PR TITLE
Add ability to filter on scopes that are not/need not be in the columns parameter

### DIFF
--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -254,7 +254,7 @@ class Datasets(object):
         for id, values in zip(scope_ids_to_be_filtered, scope_values_to_be_filtered):
             filters_additional.extend(self.get_scope_values(dataset_id, id).where_in(values).pluck('id'))
 
-        # Add filters specified in parameters 
+        # Extend the existing list of scope value filters with additional 
         filters.extend(filters_additional)
 
         return filters

--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -181,7 +181,7 @@ class Datasets(object):
         filters = self._find_scope_value_filters(columns_with_values)
 
         # If additional filters for scopes that may not be added to the transactions
-        # are sepcified, get the scope_value_id for the scope_id and scope_values
+        # are specified, get the scope_value_id for the scope_id and scope_values
         # and extend the filters list
         scope_ids_to_be_filtered = [scope['scope_id'] for scope in filter_scopes]
         scope_values_to_be_filtered = [scope['values'] for scope in filter_scopes]

--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -194,6 +194,11 @@ class Datasets(object):
         # Add filters specified in parameters 
         filters.extend(filters_additional)
 
+        # Keep only unique values of scope value ids
+        # In case a filter was added in the filter_scopes param
+        # that already existed in the columns list
+        filters = list(set(filters))
+
         # Find all aggregation methods to be sent to the dataset service.
         aggregation_methods = self._find_aggregation_methods(columns_with_scopes)
 

--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -246,9 +246,6 @@ class Datasets(object):
         that need to be filtered on.
         :rtype list
         """
-        # If additional filters for scopes that may not be added to the transactions
-        # are specified, get the scope_value_id for the scope_id and scope_values
-        # and extend the filters list
         scope_ids_to_be_filtered = [scope['scope_id'] for scope in filter_scopes]
         scope_values_to_be_filtered = [scope['values'] for scope in filter_scopes]
 

--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -158,7 +158,7 @@ class Datasets(object):
         :param datetime end_date_time: When specified, only transactions before this date are considered.
         :param str bc_id: (optional) business cell ID.
             (defaults to 'all')
-        :param list[dict] filter_scopes: (optional) When specified, filters for the mentioned scope and scope values are
+        :param list[dict] filter_scopes (optional): When specified, filters for the menitoned scope and scope values are 
             applied to the transactions.
         :param str intake_status: (Optional) If specified, transactions are fetched from the last intake of this status.
         :param list filter_transaction_ids: (Optional) If specified, only transactions with these IDs are considered.
@@ -181,11 +181,12 @@ class Datasets(object):
         filters = self._find_scope_value_filters(columns_with_values)
 
         # Add all scope value ids for additional filters and extend to the existing list.
-        filters = self._add_scope_values_for_additional_filters(filters, filter_scopes, dataset_id)
+        filters_additional = self._add_scope_values_for_additional_filters(filter_scopes, dataset_id)
 
-        # Keep only unique values of scope value ids
-        # In case a filter was added in the filter_scopes param
-        # that already existed in the columns list
+        # Extend the existing list of scope value filters.
+        filters.extend(filters_additional)
+
+        # Keep only unique values of scope value ids.
         filters = list(set(filters))
 
         # Find all aggregation methods to be sent to the dataset service.
@@ -232,32 +233,25 @@ class Datasets(object):
         # Map transactions to dicts based on the provided column keys and convert to pandas dataframe.
         return DataFrame.from_records([t.to_dict(scope_keys) for t in transactions])
 
-    def _add_scope_values_for_additional_filters(self, filters, filter_scopes, dataset_id):
+    def _add_scope_values_for_additional_filters(self, filter_scopes, dataset_id):
         """
         If additional filters for scopes that may not be added to the transactions
-        are specified, get the scope_value_id for the scope_id and scope_values
-        and extend the filters list
-        :param list filters: business cell ID.
-            (defaults to 'all')
+        are specified, get the scope_value_id for the scope_id and scope_values.
         :param list[dict] filter_scopes: filters for the mentioned scope and scope values 
-            to be applied to the transactions
-        :param int dataset_id: Dataset to retrieve scopes for
-        :return: New list of filters, extended with scope value ids 
-        that need to be filtered on.
+            to be applied to the transactions.
+        :param int dataset_id: Dataset to retrieve scopes for.
+        :return: New list of scope value ids that the data need to be filtered on.
         :rtype list
         """
-        scope_ids_to_be_filtered = [scope['scope_id'] for scope in filter_scopes]
-        scope_values_to_be_filtered = [scope['values'] for scope in filter_scopes]
 
-        filters_additional = []
+        scope_value_ids = []
 
-        for id, values in zip(scope_ids_to_be_filtered, scope_values_to_be_filtered):
-            filters_additional.extend(self.get_scope_values(dataset_id, id).where_in(values).pluck('id'))
+        for filter_scope in filter_scopes:
+            scope_id = filter_scope['scope_id']
+            scope_values = filter_scope['values']
+            scope_value_ids.extend(self.get_scope_values(dataset_id, scope_id).where_in(scope_values).pluck('id'))
 
-        # Extend the existing list of scope value filters with additional 
-        filters.extend(filters_additional)
-
-        return filters
+        return scope_value_ids
 
     def _add_scopes(self, dataset_id, columns, bc_id='all'):
         """

--- a/src/pricecypher/datasets.py
+++ b/src/pricecypher/datasets.py
@@ -158,7 +158,7 @@ class Datasets(object):
         :param datetime end_date_time: When specified, only transactions before this date are considered.
         :param str bc_id: (optional) business cell ID.
             (defaults to 'all')
-        :param list[dict] filter_scopes (optional): When specified, filters for the menitoned scope and scope values are 
+        :param list[dict] filter_scopes: (optional) When specified, filters for the mentioned scope and scope values are
             applied to the transactions.
         :param str intake_status: (Optional) If specified, transactions are fetched from the last intake of this status.
         :param list filter_transaction_ids: (Optional) If specified, only transactions with these IDs are considered.


### PR DESCRIPTION
## Proposed changes

Added a new paarmeter to the get_transactions function where the user can specify scope ids that need to be filtered along with the values to be filtered on. 

Note: This is different from the filter key within the columns parameter that is function already. Columns specified in the filter_scopes parameter will only be used for filtering and will not be added to the transactions that are returned as a result of the get_transactions functions (if the scope was not present in the columns parameter).

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
Explain here how to run your unit tests, and explain how to execute manual testing. 

### Unit testing

Explain how to run the automated tests for this system (e.g. pytest, testthat, etc.) and explain what these tests test and why.

### Manual testing

Explain how to run manual tests. If it is a bugfix, explain how to check if the bug has been resolved.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
