### PR TITLE
HOTFIX - Use `pbr` for building and include `__version__` property in top-level module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ env.bak/
 venv.bak/
 
 # End of https://www.toptal.com/developers/gitignore/api/pycharm,python
+
+# pbr
+/ChangeLog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
+    "pbr>=5.11.1",
     "setuptools>=42",
     "wheel"
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "pbr.build"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+better-abc>=0.0.3
+requests>=2.14.0
+marshmallow-dataclass>=8.5.3
+pandas>=1.4.1
+numpy>=1.18.5
+typeguard>=2.13.3
+pbr>=5.11.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pricecypher-sdk
-version = 1.0.0
 author = Deloitte Consulting B.V.
 description = Python wrapper around the different PriceCypher APIs
 long_description = file: README.md
@@ -18,16 +17,17 @@ package_dir =
     = src
 packages = find:
 python_requires = >=3.9
-install_requires =
-    better-abc>=0.0.3
-    requests>=2.14.0
-    marshmallow-dataclass>=8.5.3
-    pandas>=1.4.1
-    numpy>=1.18.5
-    typeguard>=2.13.3
+
+[pbr]
+skip_authors = true
+
+[entry_points]
+pbr.config.drivers =
+    plain = pbr.cfg.driver:Plain
 
 [options.packages.find]
 where = src
 
-[options.extras_require]
-test = mock>=1.3.0
+[extras]
+testing =
+    mock>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(
+    setup_requires=['pbr'],
+    pbr=True,
+)

--- a/src/pricecypher/__init__.py
+++ b/src/pricecypher/__init__.py
@@ -1,2 +1,6 @@
+import pbr.version
+
 from .config_sections import ConfigSections
 from .datasets import Datasets
+
+__version__ = pbr.version.VersionInfo('pricecypher_sdk').version_string()


### PR DESCRIPTION
## Proposed changes
Uses [pbr](https://docs.openstack.org/pbr/latest/index.html) for managing `setuptools` packaging needs in a consistent manner. 

Additionally, `__version__` is added to the top-level module. This allows us to use the following to determine the version of the package in clients/usages of this package.

```Python
import pricecypher

print(pricecypher.__version__)
```

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
Explain here how to run your unit tests, and explain how to execute manual testing. 

### Unit testing
n/a

### Manual testing
1. `python3 -m build`
2. Install the generated tar ball using pip
3. Try to retrieve version as shown above.

## Further comments
n/a