### PR TITLE
BREAKING CHANGE: Update Script contracts to take `get_bearer_token` function argument instead of static `bearer_token`

### DIFF
--- a/src/pricecypher/contracts/QualityTestScript.py
+++ b/src/pricecypher/contracts/QualityTestScript.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Any
+from typing import Optional, Any, Callable
 
 from pricecypher.contracts import Script, TestSuite
 
@@ -11,16 +11,16 @@ class QualityTestScript(Script, ABC):
         used in a generalized yet controlled setting.
     """
 
-    def execute(self, business_cell_id: Optional[int], bearer_token: str, user_input: dict[Any: Any]) -> Any:
-        return self.execute_tests(business_cell_id, bearer_token)
+    def execute(self, business_cell_id: Optional[int], get_bearer_token: Callable[[], str], user_input: dict[Any: Any]) -> Any:
+        return self.execute_tests(business_cell_id, get_bearer_token)
 
     @abstractmethod
-    def execute_tests(self, business_cell_id: Optional[int], bearer_token: str) -> TestSuite:
+    def execute_tests(self, business_cell_id: Optional[int], get_bearer_token: Callable[[], str]) -> TestSuite:
         """
         Execute the script to calculate the values of some scope for the given transactions.
 
         :param business_cell_id: Business cell to execute the script for, or None if running the script for all.
-        :param bearer_token: Bearer token to use for additional requests.
+        :param get_bearer_token: Function that can be invoked to retrieve an access token.
         :return: List of all test results that were performed by the test script.
         """
         raise NotImplementedError

--- a/src/pricecypher/contracts/ScopeScript.py
+++ b/src/pricecypher/contracts/ScopeScript.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, Callable
 
 from pricecypher.contracts.Script import Script
 
@@ -11,26 +11,31 @@ class ScopeScript(Script, ABC):
         which can then be used in a generalized yet controlled setting.
     """
 
-    def execute(self, business_cell_id: Optional[int], bearer_token: str, user_input: dict[Any: Any]) -> Any:
+    def execute(
+        self,
+        business_cell_id: Optional[int],
+        get_bearer_token: Callable[[], str],
+        user_input: dict[Any: Any],
+    ) -> Any:
         # Executing a scope-script like a normal script:
         # Attempt to extract the transaction IDs and continue as normal
         if 'transaction_ids' not in user_input:
             raise Exception('Expected input key "transaction_ids" not present.')
         transaction_ids: list[int] = user_input['transaction_ids']
-        return self.execute_scope_script(business_cell_id, bearer_token, transaction_ids)
+        return self.execute_scope_script(business_cell_id, get_bearer_token, transaction_ids)
 
     @abstractmethod
     def execute_scope_script(
         self,
         business_cell_id: Optional[int],
-        bearer_token: str,
-        transaction_ids: list[int]
+        get_bearer_token: Callable[[], str],
+        transaction_ids: list[int],
     ) -> dict[int, str]:
         """
         Execute the script to calculate the values of some scope for the given transactions.
 
         :param business_cell_id: Business cell to execute the script for, or None if running the script for all.
-        :param bearer_token: Bearer token to use for additional requests.
+        :param get_bearer_token: Function that can be invoked to retrieve an access token.
         :param transaction_ids: List of transaction IDs to calculate the scope values/constants for.
         :return: Dictionary mapping every transaction ID to a string value for the scope of this script.
         """

--- a/src/pricecypher/contracts/Script.py
+++ b/src/pricecypher/contracts/Script.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Annotated
+from typing import Any, Optional, Annotated, Callable
 
 
 class Script(ABC):
@@ -43,14 +43,19 @@ class Script(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def execute(self, business_cell_id: Optional[int], bearer_token: str, user_input: dict[Any: Any]) -> Any:
+    def execute(
+        self,
+        business_cell_id: Optional[int],
+        get_bearer_token: Callable[[], str],
+        user_input: dict[Any: Any],
+    ) -> Any:
         """
         Execute the script
 
         NB: All required config and scopes are assumed to be present.
 
         :param business_cell_id: Business cell to execute the script for, or None if running the script for all.
-        :param bearer_token: Bearer token to use for additional requests.
+        :param get_bearer_token: Function that can be invoked to retrieve an access token.
         :param user_input: Dictionary of additional json-serializable input provided by the caller of the script.
         :return: Any json-serializable results the script outputs.
         """


### PR DESCRIPTION
sem-ver: api-break

## Proposed changes
Update all script contracts such that they take a `get_bearer_token` function as input to their `execute` functions, instead of a static `bearer_token` input. This allows scripts to run longer than the lifetime of a single access token, while still being able to make API requests to PriceCypher Engine.

## Types of changes

What types of changes does your code introduce to this repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
Explain here how to run your unit tests, and explain how to execute manual testing. 

### Unit testing
n/a

### Manual testing
Let's test in DEV environment, together with updated Argo Runtime. See marketredesign/pc_generic_datascience_scripts#44.

## Further comments
Breaking change, so requires new major version to be released
