### PR TITLE
Auto retry failed HTTP requests for certain status codes

### DIFF
--- a/src/pricecypher/rest.py
+++ b/src/pricecypher/rest.py
@@ -140,7 +140,7 @@ class RestClient(object):
     # Returns the minimum delay window allowed (100ms)
     def MIN_REQUEST_RETRY_DELAY(self):
         return 100
-    
+
     # Returns HTTP status codes on which to attempt retries
     def RETRIABLE_STATUS_CODES(self):
         return [429, 502]

--- a/src/pricecypher/rest.py
+++ b/src/pricecypher/rest.py
@@ -143,7 +143,7 @@ class RestClient(object):
 
     # Returns HTTP status codes on which to attempt retries
     def RETRIABLE_STATUS_CODES(self):
-        return [429, 502]
+        return [408, 425, 429, 502, 503, 504]
 
     def _retry(self, make_request):
         # Track the API request attempt number

--- a/src/pricecypher/rest.py
+++ b/src/pricecypher/rest.py
@@ -140,6 +140,10 @@ class RestClient(object):
     # Returns the minimum delay window allowed (100ms)
     def MIN_REQUEST_RETRY_DELAY(self):
         return 100
+    
+    # Returns HTTP status codes on which to attempt retries
+    def RETRIABLE_STATUS_CODES(self):
+        return [429, 502]
 
     def _retry(self, make_request):
         # Track the API request attempt number
@@ -158,7 +162,7 @@ class RestClient(object):
             # Issue the request
             response = make_request()
 
-            if response.status_code != 429:
+            if response.status_code not in self.RETRIABLE_STATUS_CODES():
                 break
 
             # Try to find Retry After header in response, which specifies the number of seconds we should wait.


### PR DESCRIPTION
## Proposed changes

Added simple logic to check specific HTTP status codes on which to attempt multiple retries of HTTP request.
The retry logic remains the same.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

To be tested