### PR TITLE
Add default `None` value to optional dataclass fields

### DIFF
--- a/src/pricecypher/dataclasses/predict_result.py
+++ b/src/pricecypher/dataclasses/predict_result.py
@@ -7,15 +7,15 @@ from pricecypher.enums import Accuracy
 @dataclass(frozen=True)
 class PredictValues:
     predictive_price: float
-    max_predictive_range: Optional[float]
-    min_predictive_range: Optional[float]
+    max_predictive_range: Optional[float] = None
+    min_predictive_range: Optional[float] = None
 
 
 @dataclass(frozen=True)
 class PredictStep:
     key: str
     value: float
-    order: Optional[int]
+    order: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -30,4 +30,4 @@ class PredictResult:
     predictive_values: PredictValues
     predictive_steps: list[PredictStep]
     accuracy: Accuracy
-    version: Optional[str]
+    version: Optional[str] = None


### PR DESCRIPTION
## Proposed changes
Some dataclass fields use the `Optional` type without setting a default value. Because of this, a value for these fields must be provided when creating a new instance of the dataclass. The `Optional` type only specifies that the value may be None. By setting a default, the value for optional fields may be left out when creating a new instance of the class.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

### Unit testing
n/a

### Manual testing
See the following snippet. Before, it raises an error. This PR aims to resolve that.
```Python
from pricecypher.dataclasses import PredictValues, PredictResult, PredictStep
from pricecypher.enums import Accuracy
pv = PredictValues(0, None, None)
ps = PredictStep('', '', None)
PredictResult(pv, [ps], Accuracy.GREEN)
```

## Further comments
The `version` field of the `PredictResult` class was added in a later version than the class itself. Without the default value for this field, the addition of this field caused an unintended breaking change in the minor release. This PR patches that, fixing backward compatibility