### PR TITLE
Fix circular import `TrainModelHandler` <> `PricecypherModel`

### DIFF
--- a/src/pricecypher/contracts/handlers/train_models_handler.py
+++ b/src/pricecypher/contracts/handlers/train_models_handler.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from .base_handler import BaseHandler
 from pricecypher.enums import AccessTokenGrantType
-from pricecypher.contracts import PricecypherModel
+from ..pricecypher_model import PricecypherModel
 
 
 class TrainModelHandler(BaseHandler):


### PR DESCRIPTION
## Proposed changes
1. The `pricecypher.contracts` model imports both `TrainModelHandler` and `PricecypherModel` during `__init__`. 
2. The `TrainModelHandler` model imports `PricecypherModel form pricecypher.contracts`
3. Which in turn makes the `pricecypher.contracts` model import the `TrainModelHandler` again.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

### Unit testing
n/a

### Manual testing
Use `TrainModelHandler` somewhere (just importing it should be enough)

## Further comments
n/a