### PR TITLE
Fix `intake_status` and `environment` missing from transactions_summary request

### DIFF
--- a/src/pricecypher/endpoints/datasets.py
+++ b/src/pricecypher/endpoints/datasets.py
@@ -93,6 +93,7 @@ class _TransactionsEndpoint(BaseEndpoint):
     def __init__(self, client, base):
         self.client = client
         self.base_url = base
+        self.param_keys = {'intake_status', 'environment'}
 
     def index(self, data):
         """


### PR DESCRIPTION
## Proposed changes

**The fix:**

In the `_TransactionsEndpoint` class, for the transactions `summary` function, added request param_keys `{'intake_status', 'environment'}`

**Reason for this fix:**

When running intake on Argoworkflows, the `upload_bm` job fails at [line 461](https://github.com/marketredesign/pc_generic_datascience_scripts/blob/49e09268dc1262587df8f1f2800aa209bcb35529/jobs/upload_benchmark/src/bm_shift.py#L461), when dataset service is used to `get_transaction_summary()`. At this point, we get an error that says:

```bash
ERROR:root:404 pricecypher.sdk.internal.unknown: No query results for model [App\Models\DataIntake].
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

### Unit testing
n/a

### Manual testing
TODO

## Further comments
